### PR TITLE
add new table for word spellings, refactor schema to use word_ids

### DIFF
--- a/test/import/importer_test.py
+++ b/test/import/importer_test.py
@@ -32,7 +32,12 @@ class ImportWord(ImportTestBase):
         self.assertEqual(
             ("potato", "pəˈteɪ.təʊ"),
             self.cursor.execute(
-                "SELECT word, phonetic FROM word_phonetic").fetchone(),
+                """
+                SELECT ws.spelling, wp.phonetic
+                FROM word_phonetic AS wp
+                INNER JOIN word_spelling AS ws
+                ON wp.word_id = ws.word_id"""
+            ).fetchone(),
         )
         pass
 
@@ -51,7 +56,15 @@ class ImportWord(ImportTestBase):
                 ("theater", "ˈθiː.ə.t̬ɚ"),
                 ("theater", "ˈθɪə.tər"),
             ],
-            list(self.cursor.execute("SELECT word, phonetic FROM word_phonetic")),
+            list(
+                self.cursor.execute(
+                    """
+                    SELECT ws.spelling, wp.phonetic
+                    FROM word_phonetic AS wp
+                    INNER JOIN word_spelling AS ws
+                    ON wp.word_id = ws.word_id"""
+                )
+            ),
         )
         pass
 
@@ -86,7 +99,7 @@ class AltPhraseSplitting(unittest.TestCase):
             },
             im.alt_phrase_to_words(
                 "This... is an, 'ORDINARY!' English-sentence   with some (varying) #punctu4t1on@. e.g. dog-eat-dog ?!shouldN't wE@ just,- get along they'll, I'm Jason's?"
-            )
+            ),
         )
 
     def test_es(self):
@@ -105,7 +118,7 @@ class AltPhraseSplitting(unittest.TestCase):
             },
             im.alt_phrase_to_words(
                 "Hay 4 estadounidenses secuestrados en México: ¿qué saben las autoridades?"
-            )
+            ),
         )
 
 
@@ -139,8 +152,7 @@ class PhraseSplitting(unittest.TestCase):
         # todo: decide if this is the appropriate output (omitting .)
         self.assertEqual(
             {"dr", "mr", "mrs", "walter", "jr", "sr", "esq", "ms", "jackson"},
-            im.phrase_to_words(
-                "Dr. Mr. Mrs. Walter Jr., Sr., Esq., Ms. Jackson,"),
+            im.phrase_to_words("Dr. Mr. Mrs. Walter Jr., Sr., Esq., Ms. Jackson,"),
         )
 
     def test_spanish(self):
@@ -201,7 +213,7 @@ class PhraseSplitting(unittest.TestCase):
                 "吃",
                 "苦",
             },
-            im.phrase_to_words("小洞不补，大洞吃苦。")
+            im.phrase_to_words("小洞不补，大洞吃苦。"),
         )
 
 
@@ -225,8 +237,7 @@ class ImportPhrase(ImportTestBase):
 
 class ImportWordAssoc(ImportTestBase):
     def test_missing_assoc(self):
-        im.import_item_word_assoc(
-            self.cursor, {"type": "word_assoc", "source": {}})
+        im.import_item_word_assoc(self.cursor, {"type": "word_assoc", "source": {}})
         im.import_item_word_assoc(
             self.cursor, {"type": "word_assoc", "assocs": [], "source": {}}
         )


### PR DESCRIPTION
had to change several generator comprehensions to list comprehensions because sqlite does not allow cursors to be used in recursive calls. and generators are recursive? I don't anticipate this being a major issue, as the input to the generators originated from the JSON, which itself had to be all in memory at one point. meaning: the instantaneous memory usage is not asymptotically greater than before